### PR TITLE
Fix unbound variable in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,12 @@ fi
 
 echo "Checking python 'installer'..."
 
-Installer=$1
+if [[ $# -gt 0 ]]
+then
+    Installer=$1
+else
+    Installer="poetry"
+fi
 
 if [[ "$Installer" = "virtualenv" ]]
 then


### PR DESCRIPTION
# Fix unbound variable in install.sh

This is a proposed solution for #1.
This happens when you don't pass a parameter to the script, which as I intended reading the code is the desired behaviour if you want to install pylings using poetry, since the value `$1` is assigned to the variable `Installer` no matter what.

## Proposed solution
I added an if statement which checks if a parameter is given, otherwise I assign "poetry" to the `Installer` variable.